### PR TITLE
view画面で縮小した写真ファイルを配信するようにした

### DIFF
--- a/june_version/README.md
+++ b/june_version/README.md
@@ -10,3 +10,15 @@ $ php db/init_db.php
 ```
 
 正常に初期化が終了した場合`db/photo_share.sqlite3`が作成されているはず
+
+## 写真の一括リサイズ方法
+
+以下のコマンドを実行することで `images/` ディレクトリ内に `写真名__small.png` という縮小された写真データが一括生成される
+
+**コマンドの実行には [imagemagick](https://www.imagemagick.org/script/index.php) のインストールが必要**
+
+```
+$ ./_tool/resize_photos.bash
+```
+
+写真のアップロードをしたら自動でサイズの縮小が行われるので基本は行わなくて良い

--- a/june_version/_tools/resize_photos.bash
+++ b/june_version/_tools/resize_photos.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+images_dir=$(cd `dirname "$0"`/../images;pwd)
+for src in `ls "$images_dir"`
+do
+  if `echo "$src" | grep -q "__small"`;then
+    continue
+  fi
+  dst=`echo "$src" | sed -r "s/^(.+)\.([^\.]+)$/\1__small.\2/"`
+  convert "$images_dir/$src" -resize "640x>" "$images_dir/$dst"
+done

--- a/june_version/php/fetch_photo_info.php
+++ b/june_version/php/fetch_photo_info.php
@@ -14,6 +14,11 @@ $stmt=$db->prepare("SELECT name FROM photo");
 $stmt->execute();
 $photo_names = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($photo_names as $i => &$v) {
+    // リサイズ済みのファイルがあるならそれをオリジナルファイルの代わりに配信する
+    $resized_photo_name = preg_replace("/^(.+)\.([^\.]+)$/", "$1__small.$2", $v["name"]);
+    if (file_exists(__DIR__ . "/../images/" . $resized_photo_name)) {
+        $v["name"] = $resized_photo_name;
+    }
     $v["is_edited"] = false;
 }
 
@@ -23,6 +28,11 @@ $stmt=$db->prepare("SELECT name FROM edit");
 $stmt->execute();
 $edit_names = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($edit_names as $i => &$v) {
+    // リサイズ済みのファイルがあるならそれをオリジナルファイルの代わりに配信する
+    $resized_photo_name = preg_replace("/^(.+)\.([^\.]+)$/", "$1__small.$2", $v["name"]);
+    if (file_exists(__DIR__ . "/../images/" . $resized_photo_name)) {
+        $v["name"] = $resized_photo_name;
+    }
     $v["is_edited"] = true;
 }
 

--- a/june_version/php/register_photo_info.php
+++ b/june_version/php/register_photo_info.php
@@ -4,12 +4,31 @@
 require_once 'get_db.php';
 header("Content-type: text/json; charset=UTF-8");
 
+// コマンドが存在するか
+function checkShellCommand($command)
+{
+    $returnValue = shell_exec("$command");
+    if (empty($returnValue)) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
 //写真データ
 $photo = $_FILES['photo'];
 $photodata = $photo['tmp_name'];
-$photoname = uniqid(rand(), true) . ".png"; 
-$photopath = __DIR__ . "/../images/$photoname";
-rename($photodata, $photopath);
+$photoname = uniqid(rand(), true) . ".png";
+$photodir = __DIR__ . "/../images/";
+$photopath = $photodir . $photoname;
+rename($photodata, $photopath); // 写真データをファイルに保存
+
+if (checkShellCommand("convert")) {
+    // アップロードされた写真をリサイズする
+    $resized_photoname = str_replace(".png", "__small.png", $photoname);
+    exec("convert '$photodir$photoname' -resize '640x>' '$photodir$resized_photoname'");
+}
+
 $imagesize=getimagesize($photopath);
 $photo_width=$imagesize[0];
 $photo_height=$imagesize[1];

--- a/june_version/take_photoupload.html
+++ b/june_version/take_photoupload.html
@@ -127,7 +127,7 @@
                 contentType: false
               }).done(function (result) {
                 alert("Upload succeeded");
-                location.href = "view_photo.html";
+                location.reload()
               });
             }
           </script>

--- a/june_version/view_photo.html
+++ b/june_version/view_photo.html
@@ -103,7 +103,7 @@
 
     $('#send_photo_name').click(function (e) {
       let parent_dom = $('#photo_slide .sp-selected .sp-image').parent('a');
-      let href = parent_dom.attr('href');
+      let href = parent_dom.attr('href').replace("__small", "");
       const is_edited = parent_dom.data("is-edited")
       window.location.href = `./edit_photo.html?photo_name=${href}&is_edited=${is_edited}`
     });


### PR DESCRIPTION
## WHY

- 現状view画面でカメラで取ったオリジナルファイル（サイズ大 1枚あたり数MBクラス）を配信している
- 閲覧したときおおよそ500MB程度の写真を一括ダウンロードするのでページが重い

## WHAT

- 写真のアップロード時にオリジナルの写真ファイルとは別にサイズ縮小した写真ファイルを自動生成する（サイズ中 1枚あたり数百KB）
- view画面にアクセスしたときサイズ縮小した写真ファイルが存在するならばオリジナルファイルではなく、そちらを配信するように変更
- すでに本番サーバに上がってるような写真ファイル群を一括縮小するためのシェルスクリプトを作成した
  - `./_tools/resize_photos.bash` をコンソール上で実行する
  - 実行には `imagemagick` をインストールして `convert` コマンドを実行可能にする必要がある
- 転送データ量削減効果（Firefoxの開発者ツール上で確認）
  - before: 516.61MB
  - after: 134.33MB(-74%)
  - まだまだ多い
  - 写真数で線形的に増えていくので、より実用的にするならオンデマンドな配信方法を検討するべき